### PR TITLE
feat(shop): Stat upgrade tweaks

### DIFF
--- a/Assets/Scripts/Player/PlayerShoot.cs
+++ b/Assets/Scripts/Player/PlayerShoot.cs
@@ -243,7 +243,7 @@ public class PlayerShoot : MonoBehaviour
             return;
         }
 
-        var damage = (int)Math.Round(this._damage * weakDamageMultiplier);
+        var damage = (int)Math.Round(_damage * weakDamageMultiplier);
         var speed = Speed * weakSpeedMultiplier;
         TransformBullets(lowBulletPool, damage, speed);
 

--- a/Assets/Scripts/Player/Stats/Templates/Stat.cs
+++ b/Assets/Scripts/Player/Stats/Templates/Stat.cs
@@ -49,8 +49,8 @@ namespace Player.Stats.Templates
 
         private void SetValue(int ignored1, float value, int ignored2)
         {
+            Value = Value/BaseValue * value;
             BaseValue = value;
-            Value = value;
         }
 
         public float GetValue()


### PR DESCRIPTION
Stats that persist between scenes now only upgrade the current amount up by the same % that the max stat upgrades by. For example if a player has 25/50 hp and upgrades max hp to 100, they will now have 50/100 hp.