### PR TITLE
fix(shop): Buying flash heal gives vampiric instead

### DIFF
--- a/Assets/Scripts/Player/Special/Move/Heal.cs
+++ b/Assets/Scripts/Player/Special/Move/Heal.cs
@@ -38,7 +38,7 @@ namespace Player.Special.Move
         
         private static void HandleShopItemButtonPressed(int playerNum)
         {
-            PlayerStats.SetSpecialMove(playerNum, SpecialMoveEnum.ShootVampire);
+            PlayerStats.SetSpecialMove(playerNum, SpecialMoveEnum.MoveHeal);
         }
 
         private static void HandleShopItemButtonDisable(ShopItemButton shopItemButton)


### PR DESCRIPTION
Fix flash heal special move in shop giving vampiric instead