### PR TITLE
tweak(special): Make continuous special moves drain energy continuously

### DIFF
--- a/Assets/Scripts/Player/Special/Move/AbsorbShield.cs
+++ b/Assets/Scripts/Player/Special/Move/AbsorbShield.cs
@@ -9,7 +9,6 @@ namespace Player.Special.Move
         private const string Description = "";
         
         private bool _isEnabled;
-        private float _timer;
         
         public AbsorbShield(int playerNum) : base(playerNum, 3) { } // cost: 3
 
@@ -49,7 +48,6 @@ namespace Player.Special.Move
             if (!PlayerController.HasSpecial(PlayerNum, Cost)) return;
             if (!PlayerController.EnableShield(PlayerNum)) return;
             Enable();
-            _timer = 1;
             PlayerController.OnDeltaTimeUpdate += UpdateTimer;
             _isEnabled = true;
             PlayerSoundController.PlaySpecialEnabledSound();
@@ -92,14 +90,13 @@ namespace Player.Special.Move
         private void UpdateTimer(float deltaTime)
         {
             if (!_isEnabled) return;
-            if (_timer > 0) _timer -= deltaTime;
-            if (!PlayerController.HasSpecial(PlayerNum, Cost))
+            var usage = deltaTime * Cost;
+            if (!PlayerController.HasSpecial(PlayerNum, usage))
             {
                 Stop();
                 return;
             }
-            _timer = 1;
-            PlayerController.UseSpecial(PlayerNum, Cost);
+            PlayerController.UseSpecial(PlayerNum, usage);
         }
         
         public static void InitShopItemButton(ShopItemButton shopItemButton)

--- a/Assets/Scripts/Player/Special/Shoot/Laser.cs
+++ b/Assets/Scripts/Player/Special/Shoot/Laser.cs
@@ -12,7 +12,6 @@ namespace Player.Special.Shoot
         private PlayerLaserController _playerLaserController;
         
         private bool _isEnabled;
-        private float _timer;
 
         public Laser(int playerNum) : base(playerNum, 3) // cost: 3
         {
@@ -40,7 +39,6 @@ namespace Player.Special.Shoot
             _playerLaserController.OnForwardChange += HandleLaserForwardChange;
             _playerLaserController.OnOriginChange += HandleLaserOriginChange;
             _laser.gameObject.SetActive(true);
-            _timer = 1;
             PlayerController.OnDeltaTimeUpdate += UpdateTimer;
             _isEnabled = true;
             PlayerSoundController.PlaySpecialEnabledSound();
@@ -79,14 +77,13 @@ namespace Player.Special.Shoot
         private void UpdateTimer(float deltaTime)
         {
             if (!_isEnabled) return;
-            if (_timer > 0) _timer -= deltaTime;
-            if (!PlayerController.HasSpecial(PlayerNum, Cost))
+            var usage = deltaTime * Cost;
+            if (!PlayerController.HasSpecial(PlayerNum, usage))
             {
                 Stop();
                 return;
             }
-            _timer = 1;
-            PlayerController.UseSpecial(PlayerNum, Cost);
+            PlayerController.UseSpecial(PlayerNum, usage);
         }
 
         public void InitPlayerLaserController(PlayerLaserController playerLaserController)

--- a/Assets/Scripts/Player/Stats/PlayerStats.cs
+++ b/Assets/Scripts/Player/Stats/PlayerStats.cs
@@ -60,18 +60,18 @@ namespace Player.Stats
 
             public Player()
             {
-                Damage = new("Attack Damage", 10, 2, 0.5f, 50, 25);
-                EnergyMax = new("Max Energy", 10, 30, 10, 50, 25);
-                EnergyAbsorb = new("Energy Absorb", 10, 1f, 0.1f, 50, 25);
-                Energy = new("Energy", EnergyMax);
-                SpecialAbsorb = new("Special Absorb Rate", 10, 2, 0.2f, 50, 75);
-                SpecialDamage = new("Special Damage Rate", 10, 0.15f, 0.015f, 50, 75);
-                SpecialDamaged = new("Special Damaged Rate", 10, 0.5f, 0.05f, 50, 75);
-                SpecialGain = new("Special Gain", 10, 150, 150, false, SpecialAbsorb, SpecialDamage, SpecialDamaged);
-                EnergyCostDash = new("Dash Energy Cost", 9, 15, -1f, 100, 75);
-                EnergyShare = new("Energy Share", 10, 0.1f, 0.1f, 100, 100);
-                Special = new("Special", SpecialMax, false);
-                PlayerStats = new() { Damage, EnergyMax, EnergyAbsorb, SpecialGain, EnergyCostDash, EnergyShare };
+                Damage = new UpgradeableLinearStat("Attack Damage", 10, 2, 0.5f, 50, 25);
+                EnergyMax = new UpgradeableLinearStat("Max Energy", 10, 30, 10, 50, 25);
+                EnergyAbsorb = new UpgradeableLinearStat("Energy Absorb", 10, 1f, 0.1f, 50, 25);
+                Energy = new Stat("Energy", EnergyMax);
+                SpecialAbsorb = new UpgradeableLinearStat("Special Absorb Rate", 10, 2, 0.2f, 50, 75);
+                SpecialDamage = new UpgradeableLinearStat("Special Damage Rate", 10, 0.15f, 0.015f, 50, 75);
+                SpecialDamaged = new UpgradeableLinearStat("Special Damaged Rate", 10, 0.5f, 0.05f, 50, 75);
+                SpecialGain = new GroupedUpgradeableStat("Special Gain", 10, 150, 150, false, SpecialAbsorb, SpecialDamage, SpecialDamaged);
+                EnergyCostDash = new UpgradeableLinearStat("Dash Energy Cost", 9, 15, -1f, 100, 75);
+                EnergyShare = new UpgradeableLinearStat("Energy Share", 10, 0.1f, 0.1f, 100, 100);
+                Special = new Stat("Special", SpecialMax, false);
+                PlayerStats = new List<UpgradeableStat> { Damage, EnergyMax, EnergyAbsorb, SpecialGain, EnergyCostDash, EnergyShare };
                 Special.SetValue(0);
             }
 


### PR DESCRIPTION
Change AbsorbShield and Laser to take special cost continuously rather than in bursts after 1 second. Makes energy last longer for players if they simply flash the special moves on as a panic button.